### PR TITLE
Prevent `password` from leaking in debug logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5
+  - Prevent `password` leakage in the debug logs [#10](https://github.com/logstash-plugins/logstash-output-jira/pull/10)
+
 ## 3.0.4
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -95,7 +95,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-assignee>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-issuetypeid>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-password>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-password>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-priority>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-projectid>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-reporter>> |<<string,string>>|No
@@ -138,7 +138,7 @@ JIRA Issuetype number
 ===== `password` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 

--- a/lib/logstash/outputs/jira.rb
+++ b/lib/logstash/outputs/jira.rb
@@ -73,7 +73,7 @@ class LogStash::Outputs::Jira < LogStash::Outputs::Base
   config :host, :validate => :string
 
   config :username, :validate => :string, :required => true
-  config :password, :validate => :string, :required => true
+  config :password, :validate => :password, :required => true
 
   # Javalicious has no proxy support
 ###
@@ -126,7 +126,7 @@ class LogStash::Outputs::Jira < LogStash::Outputs::Base
 
     Jiralicious.configure do |config|
       config.username = @username
-      config.password = @password
+      config.password = @password.value
       config.uri = @host
       config.auth_type = :basic
       config.api_version = "latest"

--- a/logstash-output-jira.gemspec
+++ b/logstash-output-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-jira'
-  s.version         = '3.0.4'
+  s.version         = '3.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Create jira tickets based on events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/jira_spec.rb
+++ b/spec/outputs/jira_spec.rb
@@ -2,4 +2,25 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/jira"
 
 describe LogStash::Outputs::Jira do
+
+  let(:plugin) { described_class.new(config) }
+
+  describe "debugging `password`" do
+    let(:config) {{
+      "username" => "jira-user-name",
+      "password" => "$ecre&-key",
+      "projectid" => "my-project-id",
+      "issuetypeid" => "issue-type-id",
+      "summary" => "JIRA issue summary",
+      "priority" => "High"
+    }}
+
+    it "should not show origin value" do
+      expect(plugin.logger).to receive(:debug).with('<password>')
+
+      plugin.register
+      plugin.logger.send(:debug, plugin.password.to_s)
+    end
+  end
+
 end

--- a/spec/outputs/jira_spec.rb
+++ b/spec/outputs/jira_spec.rb
@@ -1,6 +1,5 @@
-require "logstash/pipeline"
-require "logstash/outputs/jira"
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/outputs/jira"
 
 describe LogStash::Outputs::Jira do
 end


### PR DESCRIPTION
When running Logstash with `--config.debug` option, `password` can be seen in the debug logs. This change changes `password` type to `password` to prevent from leaks.

- Closes #9 